### PR TITLE
feat: adding support for missing Dnscrypt formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## @leichtgewicht/dnsstamp
+
+`@leichtgewicht/dnsstamp` is a fork of [dnsstamp](https://github.com/rs/node-dnsstamp) with the PR
+
+- https://github.com/rs/node-dnsstamp/pull/1
+
+merged in.
+
 # DNS Stamp
 
 This node module provides a simple API to parse and generate [DNS Stamp](https://dnscrypt.info/stamps-specifications/) as defined by [Frank Denis](https://twitter.com/jedisct1).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "dnsstamp",
-  "version": "1.1.3",
+  "name": "@leichtgewicht/dnsstamp",
+  "version": "1.1.4",
   "description": "DNS Stamp de/encoder",
   "main": "dist/stamp.js",
   "scripts": {

--- a/stamp.ts
+++ b/stamp.ts
@@ -7,6 +7,9 @@ enum Protocol {
     DOH,
     DOT,
     Plain,
+    ODOH,
+    AnonymizedRelay = 0x81,
+    ODOHRelay = 0x85,
 }
 
 export namespace DNSStamp {
@@ -59,7 +62,7 @@ export namespace DNSStamp {
         }
     }
 
-    export class DOH {
+    export class ODOH {
         props = new Properties();
 
         // hostname is the server host name which will also be used as a SNI name.
@@ -68,13 +71,36 @@ export namespace DNSStamp {
         // (neither URL-encoded nor punycode).
         hostName = "";
 
+        // path is the absolute URI path, such as /.well-known/dns-query.
+        path = "";
+
+        // Creates a new Oblivious DNS over HTTPS stamp.
+        //
+        // @param addr is the IP address of the server.It can be an empty
+        // string, or just a port number, represented with a preceding colon
+        // (:443). In that case, the host name will be resolved to an IP address
+        // using another resolver.
+        constructor(init?: Partial<ODOH>) {
+            Object.assign(this, init);
+        }
+
+        public toString(): string {
+            let props = this.props.toNumber();
+
+            let v = [Protocol.ODOH, props, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+            let hostName = this.hostName.split("").map(c => c.charCodeAt(0));
+            v.push(hostName.length, ...hostName);
+            let path = this.path.split("").map(c => c.charCodeAt(0));
+            v.push(path.length, ...path);
+            return `sdns://${URLSafeBase64.encode(Buffer.from(v))}`;
+        }
+    }
+
+    export class DOH extends ODOH {
         // hashi is the SHA256 digest of one of the TBS certificate found in the
         // validation chain, typically the certificate used to sign the resolver’s
         // certificate. Multiple hashes can be provided for seamless rotations.
         hash = "";
-
-        // path is the absolute URI path, such as /.well-known/dns-query.
-        path = "";
 
         // Creates a new DNS over HTTPS stamp.
         //
@@ -83,14 +109,19 @@ export namespace DNSStamp {
         // (:443). In that case, the host name will be resolved to an IP address
         // using another resolver.
         constructor(readonly addr: string, init?: Partial<DOH>) {
+            super(init);
             Object.assign(this, init);
         }
 
         public toString(): string {
+            return this._toString(Protocol.DOH);
+        }
+
+        _toString (protocol: Protocol) {
             let props = this.props.toNumber();
             let addr = this.addr.split("").map(c => c.charCodeAt(0));
 
-            let v = [Protocol.DOH, props, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+            let v = [protocol, props, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
             v.push(addr.length, ...addr);
             let hash = Buffer.from(this.hash.replace(/[: \t]/g, ""), "hex");
             v.push(hash.length, ...hash);
@@ -121,7 +152,7 @@ export namespace DNSStamp {
         // resolved to an IP address using another resolver. IPv6 strings must
         // be included in square brackets: [fe80::6d6d:f72c:3ad:60b8]. Scopes
         // are permitted.
-        constructor(readonly addr: string, init?: Partial<DOH>) {
+        constructor(readonly addr: string, init?: Partial<DOT>) {
             Object.assign(this, init);
         }
 
@@ -149,7 +180,7 @@ export namespace DNSStamp {
         // resolved to an IP address using another resolver. IPv6 strings must
         // be included in square brackets: [fe80::6d6d:f72c:3ad:60b8]. Scopes
         // are permitted.
-        constructor(readonly addr: string, init?: Partial<DOH>) {
+        constructor(readonly addr: string, init?: Partial<Plain>) {
             Object.assign(this, init);
         }
 
@@ -163,11 +194,46 @@ export namespace DNSStamp {
         }
     }
 
+    export class AnonymizedRelay {
+        addr: string;
+
+        // Creates a new Plain DNS stamp.
+        //
+        // @param addr is the IP address of the server. It can be an empty
+        // string, or just a port number. In that case, the host name will be
+        // resolved to an IP address using another resolver. IPv6 strings must
+        // be included in square brackets: [fe80::6d6d:f72c:3ad:60b8]. Scopes
+        // are permitted.
+        constructor(addr: string) {
+            this.addr = addr;
+        }
+
+        public toString(): string {
+            let addr = this.addr.split("").map(c => c.charCodeAt(0));
+
+            let v = [Protocol.AnonymizedRelay];
+            v.push(addr.length, ...addr);
+            return `sdns://${URLSafeBase64.encode(Buffer.from(v))}`;
+        }
+    }
+
+    export class ODOHRelay extends DOH {
+        public toString(): string {
+            return this._toString(Protocol.ODOHRelay);
+        }
+    }
+
     export function parse(stamp: string): Stamp {
         if (stamp.substr(0, 7) !== "sdns://") {
             throw new Error("invalid scheme");
         }
         let bin = URLSafeBase64.decode(stamp.substr(7));
+        const type = bin[0];
+        if (type === Protocol.AnonymizedRelay) {
+            const addrLen = bin[1];
+            const addr = bin.slice(2, 2 + addrLen).toString("utf-8");
+            return new AnonymizedRelay(addr);
+        }
         const props = new Properties({
             dnssec: !!((bin[1] >> 0) & 1),
             nolog: !!((bin[1] >> 1) & 1),
@@ -177,7 +243,7 @@ export namespace DNSStamp {
         let addrLen = bin[i++];
         const addr = bin.slice(i, i + addrLen).toString("utf-8");
         i += addrLen;
-        switch (bin[0]) {
+        switch (type) {
             case Protocol.DNSCrypt: {
                 let pkLen = bin[i++];
                 const pk = bin.slice(i, i + pkLen).toString("hex");
@@ -186,7 +252,8 @@ export namespace DNSStamp {
                 const providerName = bin.slice(i, i + providerNameLen).toString("utf-8");
                 return new DNSCrypt(addr, { props, pk, providerName });
             }
-            case Protocol.DOH: {
+            case Protocol.DOH:
+            case Protocol.ODOHRelay: {
                 const hashLen = bin[i++];
                 const hash = bin.slice(i, i + hashLen).toString("hex");
                 i += hashLen;
@@ -195,7 +262,11 @@ export namespace DNSStamp {
                 i += hostNameLen;
                 const pathLen = bin[i++];
                 const path = bin.slice(i, i + pathLen).toString("utf-8");
-                return new DOH(addr, { props, hash, hostName, path });
+                if (type === Protocol.DOH) {
+                    return new DOH(addr, { props, hash, hostName, path });
+                } else {
+                    return new ODOHRelay(addr, { props, hash, hostName, path });
+                }
             }
             case Protocol.DOT: {
                 const hashLen = bin[i++];
@@ -208,6 +279,11 @@ export namespace DNSStamp {
             }
             case Protocol.Plain: {
                 return new Plain(addr, { props });
+            }
+            case Protocol.ODOH: {
+                const pathLen = bin[i++];
+                const path = bin.slice(i, i + pathLen).toString("utf-8");
+                return new ODOH({ props, hostName: addr, path });
             }
         }
 

--- a/test.ts
+++ b/test.ts
@@ -152,6 +152,86 @@ const tests: { [s: string]: Array<test> } = {
                 }),
             }),
         },
+    ],
+    'ODOH': [
+        {
+            name: 'default values',
+            sdns: 'sdns://BQcAAAAAAAAAAAA',
+            obj: new DNSStamp.ODOH({
+                hostName: '',
+                path: ''
+            })
+        },
+        {
+            name: 'with hostName',
+            sdns: 'sdns://BQcAAAAAAAAAA2ZvbwA',
+            obj: new DNSStamp.ODOH({
+                hostName: 'foo'
+            })
+        },
+        {
+            name: 'with path',
+            sdns: 'sdns://BQcAAAAAAAAAAAQvZm9v',
+            obj: new DNSStamp.ODOH({
+                path: '/foo'
+            })
+        }
+    ],
+    'AnonymizedRelay': [
+        {
+            name: 'empty',
+            sdns: 'sdns://gQA',
+            obj: new DNSStamp.AnonymizedRelay('')
+        },
+        {
+            name: 'with addr',
+            sdns: 'sdns://gQNmb28',
+            obj: new DNSStamp.AnonymizedRelay('foo')
+        }
+    ],
+    'ODOHRelay': [
+        {
+            name: 'default values',
+            sdns: 'sdns://hQcAAAAAAAAAAAAAAA',
+            obj: new DNSStamp.ODOHRelay('', {}),
+        },
+        {
+            name: 'with addr',
+            sdns: 'sdns://hQcAAAAAAAAAA2ZvbwAAAA',
+            obj: new DNSStamp.ODOHRelay('foo', {}),
+        },
+        {
+            name: 'with hostname',
+            sdns: 'sdns://hQcAAAAAAAAAAAADZm9vAA',
+            obj: new DNSStamp.ODOHRelay('', {
+                hostName: 'foo',
+            }),
+        },
+        {
+            name: 'with hash',
+            sdns: 'sdns://hQcAAAAAAAAAAAPwC6QAAA',
+            obj: new DNSStamp.ODOHRelay('', {
+                hash: 'f00ba4',
+            }),
+        },
+        {
+            name: 'with path',
+            sdns: 'sdns://hQcAAAAAAAAAAAAABC9mb28',
+            obj: new DNSStamp.ODOHRelay('', {
+                path: '/foo',
+            }),
+        },
+        {
+            name: 'all props false',
+            sdns: 'sdns://hQAAAAAAAAAAAAAAAA',
+            obj: new DNSStamp.ODOHRelay('', {
+                props: new DNSStamp.Properties({
+                    nofilter: false,
+                    nolog: false,
+                    dnssec: false,
+                }),
+            }),
+        },
     ]
 };
 


### PR DESCRIPTION
I noticed that a few formats `0x05`, `0x81` and `0x85` as described in https://dnscrypt.info/stamps-specifications/ are not covered in this implementation.

This PR adds the missing formats.